### PR TITLE
configure: Do not add C++ compiler flags to CPPFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,6 @@ LT_PREREQ([2.2])
 LT_INIT([win32-dll])
 
 CXXFLAGS="$CXXFLAGS -std=c++14 -pedantic -g"
-CPPFLAGS="$CPPFLAGS -std=c++14"
 CFLAGS="$CFLAGS -g"
 
 AX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"


### PR DESCRIPTION
CPPFLAGS is for c pre-processor and thusly added to CFLAGS as as well as
CXXFLAGS, -std=c++14 is only valid for C++ compiler, therefore do not
add it to CPPFLAGS

Signed-off-by: Khem Raj <raj.khem@gmail.com>